### PR TITLE
docs: change order of instructions in README to reflect build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Please inform the author about possible legal issues before turning to a lawyer.
 
 ## Building
 
-1. Download build dependencies
-   1. JDK 
+1. Download and install build dependencies
+   1. JDK 1.8 (or any newer version)
    2. Maven
-2. Build a runnable jar file:
+2. Build a runnable self-contained jar file:
 
 ```bash
 > mvn clean package

--- a/README.md
+++ b/README.md
@@ -3,13 +3,40 @@
 A reader in pure Java for the `*.irb` file format by InfraTec,  
 inspired by https://github.com/tomsoftware/Irbis-File-Format .
 
+This program can be used either as a Maven dependency within another program
+or as a stand-alone commandline utility.
+
+## Legal disclaimer
+
 This is a pure hobby project. No copyright infringements or similar is intended.  
 Please inform the author about possible legal issues before turning to a lawyer.
 
-## Usage
+## Building
 
-This program can be used either as a Maven dependency within another program
-or as a stand-alone commandline utility.
+1. Download build dependencies
+   1. JDK 
+   2. Maven
+2. Build a runnable jar file:
+
+```bash
+> mvn clean package
+```
+
+The output will be at `target/irb-1.0.1.jar`.
+
+## Use as a Maven dependency
+
+You can include this project as a dependency in Maven:
+
+```xml
+<dependency>
+    <groupId>de.labathome</groupId>
+    <artifactId>irb</artifactId>
+    <version>1.0.1</version>
+</dependency>
+```
+
+## Command-line Usage
 
 Execute the jar with the `*.irb` file as first command line argument:
  
@@ -39,28 +66,11 @@ You can fix this by telling JyPlot about your Python installation by creating a 
 
 The text output files should nevertheless get created.
 
-## Building
-
-1. Make a jar:
-
-```bash
-> mvn clean package
-```
-
-The output will be at `target/irb-1.0.1.jar`.
-
-Otherwise, you can include this project as a dependency in Maven:
-
-```xml
-<dependency>
-    <groupId>de.labathome</groupId>
-    <artifactId>irb</artifactId>
-    <version>1.0.1</version>
-</dependency>
-```
-
 ## Contributers
 
  * [jonathanschilling](https://github.com/jonathanschilling)
  * [benjaminSchilling33](https://github.com/benjaminschilling33)
- 
+
+## License
+
+SPDX-License-Identifier: Apache-2.0

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,15 @@
 		<system>GitHub Issues</system>
 	</issueManagement>
 
+	<repositories>
+		<repository>
+			<id>aliceinnets-central</id>
+			<name>master</name>
+			<url>https://raw.github.com/aliceinnets/maven-repository/master/</url>
+			<layout>default</layout>
+		</repository>
+	</repositories>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.commons</groupId>


### PR DESCRIPTION
this pull request changes the order of build instructions in the README to reflect the order of the build process

To-do;

* [x] Required JDK Version
* [x] Where to get the java-jyplot.jar